### PR TITLE
pin version for scikit-learn

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - jupyter
   - xarray
   - matplotlib
-  - scikit-learn
+  - scikit-learn==1.3.*
   - scikit-image
   - intake
   - intake-xarray


### PR DESCRIPTION
The PR add pinned version to load a trained model using scikit-learn version 1.3.*